### PR TITLE
fix: code syntax errors in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ func main() {
                              gateapi.GateAPIV4{
                                  Key:    "YOUR_API_KEY",
                                  Secret: "YOUR_API_SECRET",
-                             }
+                             },
                             )
     
     result, _, err := client.AccountApi.GetAccountDetail(ctx)


### PR DESCRIPTION
<img width="877" alt="img" src="https://github.com/user-attachments/assets/2d25d9f4-504c-47cf-abfd-f27109c596c7" />
