### PR TITLE
fix: create sub account key error

### DIFF
--- a/api_sub_account.go
+++ b/api_sub_account.go
@@ -11,11 +11,12 @@ package gateapi
 
 import (
 	"context"
-	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -413,14 +414,14 @@ CreateSubAccountKeys Create API Key of the sub-account
 
 @return []SubAccountKey
 */
-func (a *SubAccountApiService) CreateSubAccountKeys(ctx context.Context, userId int64, subAccountKey SubAccountKey) ([]SubAccountKey, *http.Response, error) {
+func (a *SubAccountApiService) CreateSubAccountKeys(ctx context.Context, userId int64, subAccountKey SubAccountKey) (SubAccountKey, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		localVarReturnValue  []SubAccountKey
+		localVarReturnValue  SubAccountKey
 	)
 
 	// create path and map variables

--- a/model_sub_account_key.go
+++ b/model_sub_account_key.go
@@ -21,6 +21,8 @@ type SubAccountKey struct {
 	IpWhitelist []string `json:"ip_whitelist,omitempty"`
 	// API Key
 	Key string `json:"key,omitempty"`
+	// API Secret Key
+	Secret string `json:"secret,omitempty"`
 	// State 1 - normal 2 - locked 3 - frozen
 	State int32 `json:"state,omitempty"`
 	// Creation time

--- a/model_sub_account_key.go
+++ b/model_sub_account_key.go
@@ -11,7 +11,7 @@ package gateapi
 
 type SubAccountKey struct {
 	// User ID
-	UserId string `json:"user_id,omitempty"`
+	UserId int64 `json:"user_id,omitempty"`
 	// Mode: 1 - classic 2 - portfolio account
 	Mode int32 `json:"mode,omitempty"`
 	// API key name


### PR DESCRIPTION
fix: In the CreateSubAccountKeys function, based on observing the API response, the return value should be SubAccountKey instead of []SubAccountKey. Also, the UserId field in the SubAccountKey struct should be int64 (to be consistent with SubAccount) rather than string.